### PR TITLE
Fix warning and error of package-lint

### DIFF
--- a/lxc-tramp.el
+++ b/lxc-tramp.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/montag451/lxc-tramp
 ;; Keywords: lxc, convenience
 ;; Version: 0.1.0
-;; Package-Requires: (cl-lib)
+;; Package-Requires: ((emacs "24") (cl-lib "0.6"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
1:64: warning: You should depend on (emacs "24") if you need lexical-binding.
9:1: error: Expected (package-name "version-num"), but found cl-lib.